### PR TITLE
Update README.md for LWS vocoder to link to actual github implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Note this is still WIP and I will update once the training is complete and worki
 1. batching
 2. add regularization such as dropout, layer normalization, etc
 3. improve UI/pipeline for loading data and generating custom setences
-4. replace lws vocoder with sampleRNN/fft-net/wavenet
+4. replace [lws](https://github.com/Jonathan-LeRoux/lws) vocoder with sampleRNN/fft-net/wavenet


### PR DESCRIPTION
Provide link to github repo hosting the LWS vocoder (top search result on github) for better user access in case they want to link the vocoder.